### PR TITLE
Disabled tracing by default for testing

### DIFF
--- a/nf-test.config
+++ b/nf-test.config
@@ -4,5 +4,6 @@ config {
     workDir ".nf-test"
     configFile "tests/nextflow.config"
     profile "docker"
+    withTrace false
 
 }


### PR DESCRIPTION
This fixes the issue where the following exception would be printed for tests:

```
Test [e81aa0b7] 'Test seqkit_stats' java.io.IOException: Error on record number 2: The number of data elements is not the same as the number of header elements. Expected 18, found 7.
        at com.opencsv.CSVReaderHeaderAware.readMap(CSVReaderHeaderAware.java:119)
        at com.askimed.nf.test.lang.WorkflowTrace.<init>(WorkflowTrace.java:25)
        at com.askimed.nf.test.lang.WorkflowMeta.loadFromFolder(WorkflowMeta.java:69)
...
```

The fix is to disable creating the trace file when testing (as described in https://www.nf-test.com/docs/configuration/). This does not impact the behaviour of the tests.