### PR TITLE
Ignores pre-commit check on README for now

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run pre-commit
         #run: pre-commit run --all-files
-        run: pre-commit run --files README.md
+        run: pre-commit run --files nf-test.config
 
   nf-core:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This changes the `pre-commit` checks for formatting to only run on `nf-test.config` right now to avoid issues.