### PR TITLE
Fix/customdumpsoftwareversions

### DIFF
--- a/modules/local/gzip_files.nf
+++ b/modules/local/gzip_files.nf
@@ -23,7 +23,7 @@ process GZIP_FILES {
     gzip -c ${file_in} > ${output_name}
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        gzip: \$(echo \$(gzip --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
+        gzip: \$(echo \$(gzip --version 2>&1 | head -n 1 ) | sed 's/^.*gzip //')
     END_VERSIONS
     """
 

--- a/modules/local/gzip_files.nf
+++ b/modules/local/gzip_files.nf
@@ -23,7 +23,7 @@ process GZIP_FILES {
     gzip -c ${file_in} > ${output_name}
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        gzip: \$(echo \$(gzip --version 2>&1 | head -n 1 ) | sed 's/^.*gzip //')
+        gzip: \$(echo \$(gzip --help 2>&1 | head -n 1 ) | sed -e 's/ (.*//')
     END_VERSIONS
     """
 


### PR DESCRIPTION
This fixes an error when generating the software versions file due to an invalid command for extracting the version of gzip.