### PR TITLE
Set default branch to main in manifest

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1027,6 +1027,7 @@ manifest {
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
     version         = '0.1.0'
+    defaultBranch   = 'main'
     doi             = ''
 }
 


### PR DESCRIPTION
Sets default branch in the manifest file to `main` so that you can run the pipeline without specifying the version using `-r [TAG]`.

Without this fix, if you run like `nextflow run phac-nml/mikrokondo ...` you will get the following error:

```
Project `phac-nml/mikrokondo` is currently stickied on revision: main -- you need to explicitly specify a revision with the option `-r` in order to use it
```

This was a change that was already previously done with e.g., SNVPhyl:

https://github.com/phac-nml/snvphylnfc/blob/adafa83a72caf490963db588f334f36254af156a/nextflow.config#L213

This PR is going to `main` so that the current release of the pipeline will run after merging.