### PR TITLE
Patch/sistr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## v0.2.1 - [Unreleased]
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### `Fixed`
+
+- Parsed table values would not show up properly if values were missing resolving issue [Issue 82](https://github.com/phac-nml/mikrokondo/issues/82)
+
 ## v0.2.0 - [2024-05-14]
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.2.1 - [Unreleased]
+## [0.2.1] - 2024-06-03
 
 ### `Fixed`
 
-- Parsed table values would not show up properly if values were missing resolving issue [Issue 82](https://github.com/phac-nml/mikrokondo/issues/82)
+- Parsed table values would not show up properly if values were missing resolving issue See [PR 83](https://github.com/phac-nml/mikrokondo/pull/83)
+- Fixed mismatched description for minimap2 and mash databases. See [PR 83](https://github.com/phac-nml/mikrokondo/pull/83)
 
-## v0.2.0 - [2024-05-14]
+## [0.2.0] - 2024-05-14
 
 ### `Added`
 
@@ -43,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated StarAMR to version 0.10.0. See [PR 74](https://github.com/phac-nml/mikrokondo/pull/74)
 
-## v0.1.2 - [2024-05-02]
+## [0.1.2] - 2024-05-02
 
 ### Changed
 
@@ -52,13 +53,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set `--kraken2_db` to be a required parameter for the pipeline. See [PR 71](https://github.com/phac-nml/mikrokondo/pull/71)
 - Hide bakta parameters from IRIDA Next UI. See [PR 71](https://github.com/phac-nml/mikrokondo/pull/71)
 
-## v0.1.1 - [2024-04-22]
+## [0.1.1] - 2024-04-22
 
 ### Changed
 
 - Switched the resource labels for **parse_fastp**, **select_pointfinder**, **report**, and **parse_kat** from `process_low` to `process_single` as they are all configured to run on the local Nextflow machine. See [PR 67](https://github.com/phac-nml/mikrokondo/pull/67)
 
-## v0.1.0 - [2024-03-22]
+## [0.1.0] - 2024-03-22
 
 Initial release of phac-nml/mikrokondo. Mikrokondo currently supports: read trimming and quality control, contamination detection, assembly (isolate, metagenomic or hybrid), annotation, AMR detection and subtyping of genomic sequencing data targeting bacterial or metagenomic data.
 
@@ -85,3 +86,9 @@ Initial release of phac-nml/mikrokondo. Mikrokondo currently supports: read trim
 - Changed salmonella default default coverage to 40
 
 - Added integration testing using [nf-test](https://www.nf-test.com/).
+
+[0.2.1]: https://github.com/phac-nml/mikrokondo/releases/tag/0.2.1
+[0.2.0]: https://github.com/phac-nml/mikrokondo/releases/tag/0.2.0
+[0.1.2]: https://github.com/phac-nml/mikrokondo/releases/tag/0.1.2
+[0.1.1]: https://github.com/phac-nml/mikrokondo/releases/tag/0.1.1
+[0.1.0]: https://github.com/phac-nml/mikrokondo/releases/tag/0.1.0

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -807,9 +807,7 @@ def table_values(file_path, header_p, seperator, headers=null){
     try {
         rows_list = file_path.splitCsv(header: (header_p ? true : headers), sep:seperator)
     } catch (java.lang.IllegalStateException e) {
-        // Probably not the best solution since messages could change with different versions
-        // of Nextflow, but there isn't a way to get any more specific exception type
-        if (header_p && e.getMessage() == "Empty header columns are not allowed in CSV file") {
+        if (header_p) {
             // Attempt to read file assuming first line is header line with missing value
             def header_line = file_path.splitText()[0].trim()
             def headers_from_file = header_line.split(seperator)

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -804,7 +804,7 @@ def table_values(file_path, header_p, seperator, headers=null){
     def converted_data = [:]
     def idx = 0
     def lines_read = false
-    def missing_value = ''
+    def missing_value = 'NoData'
     def default_index_col = "__default_index__"
     file_path.withReader{
         String line

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -808,7 +808,9 @@ def table_values(file_path, header_p, seperator, headers=null){
 
     // Reads two lines (up to one header line + one row) for making decisions on how to parse the file
     def file_lines = file_path.splitText(limit: 2)
-    if (!header_p) {
+    if (!header_p && headers == null) {
+        throw new Exception("Header is not provided in file [header_p=${header_p}], but headers passed to function is null")
+    } else if (!header_p) {
         if (file_lines.size() == 0) {
             // headers were not in the file, and file size is 0, so return missing data based
             // on passed headers
@@ -851,13 +853,13 @@ def table_values(file_path, header_p, seperator, headers=null){
             def row_line1 = file_lines[1].replaceAll('(\n|\r\n)$', '')
             def row_line1_columns = row_line1.split(seperator, -1)
             if (headers_from_file.size() != row_line1_columns.size()) {
-                throw new java.lang.IllegalStateException("Mismatched number of headers ${headers_from_file} and column values ${row_line1_columns} for file ${file_path}")
+                throw new Exception("Mismatched number of headers ${headers_from_file} and column values ${row_line1_columns} for file ${file_path}")
             }
 
             if (use_modified_headers_from_file) {
                 rows_list = file_path.splitCsv(header: headers_from_file as List, sep:seperator, skip: 1)
             } else {
-                rows_list = file_path.splitCsv(header: (header_p ? true : headers), sep:seperator)
+                rows_list = file_path.splitCsv(header: true, sep:seperator)
             }
         }
     }

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -804,7 +804,7 @@ def table_values(file_path, header_p, seperator, headers=null){
     def converted_data = [:]
     def idx = 0
     def lines_read = false
-    def missing_value = "NoData"
+    def missing_value = ''
     def default_index_col = "__default_index__"
     file_path.withReader{
         String line
@@ -815,13 +815,13 @@ def table_values(file_path, header_p, seperator, headers=null){
             def missing_headers = 0
             if(split_header.size() > 1){
                 for(col_header in split_header[1..-1]){ // skip first column as it is allowed to be empty
-                    if(!col_header){
+                    if(col_header == null || col_header == ''){
                         missing_headers++;
                     }
                 }
             }
 
-            if(missing_headers){
+            if(missing_headers != 0){
                 error("Missing multiple column headers in ${file_path}. You may need to pass in column headers in the nextflow.config file.")
             }
 
@@ -854,7 +854,7 @@ def table_values(file_path, header_p, seperator, headers=null){
             lines_read = true
         }
         if(!lines_read){
-            converted_data[idx] = [split_header, Collections.nCopies(split_header.size, missing_value)].transpose().collectEntries()
+            converted_data[idx] = [split_header, Collections.nCopies(split_header.size(), missing_value)].transpose().collectEntries()
         }
 
     }

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -811,8 +811,18 @@ def table_values(file_path, header_p, seperator, headers=null){
         // Catch exception here to deal with situation where the very first header is missing
         if (header_p) {
             // Attempt to read file assuming first line is header line with missing value
-            def header_line = file_path.splitText()[0].trim()
+            def file_lines = file_path.splitText()
+            def header_line = file_lines[0].trim()
+            def values_line1 = file_lines[1].trim()
             def headers_from_file = header_line.split(seperator)
+            def value1_columns = values_line1.split(seperator)
+
+            // If you pass a list of headers, then splitCsv does not seem to check to make sure
+            // the list has the same number as the values columns in the file, so I need to check this here
+            if (headers_from_file.size() != value1_columns.size()) {
+                throw new java.lang.IllegalStateException("Mismatched number of headers ${headers_from_file} and column values ${value1_columns} for file ${file_path}")
+            }
+
             def count_missing_headers = headers_from_file.collect{ is_missing(it) ? 1 : 0 }.sum()
             if (count_missing_headers > 1) {
                 throw e

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -839,7 +839,7 @@ def table_values(file_path, header_p, seperator, headers=null){
         while(line = it.readLine()){
             split_line = line.split(seperator) // split will allow for missing values
             // Transpose, and collect converts the data to a map
-            if(split_line.size() != split_header.size()){
+            if(split_line.size() > split_header.size()){
                 error("The number of values in ${file_path} differs from number of columns headers ${split_header}")
             }
 

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -804,24 +804,57 @@ def table_values(file_path, header_p, seperator, headers=null){
     def converted_data = [:]
     def idx = 0
     def lines_read = false
+    def missing_value = "NoData"
+    def default_index_col = "__default_index__"
     file_path.withReader{
         String line
         if(header_p){
             header = it.readLine()
-            split_header = header.tokenize(seperator)
+            split_header = header.split(seperator)
+
+            def missing_headers = 0
+            if(split_header.size() > 1){
+                for(col_header in split_header[1..-1]){ // skip first column as it is allowed to be empty
+                    if(!col_header){
+                        missing_headers++;
+                    }
+                }
+            }
+
+            if(missing_headers){
+                error("Missing multiple column headers in ${file_path}. You may need to pass in column headers in the nextflow.config file.")
+            }
+
+            if(!split_header[0] && ( split_header.size() == 1 || split_header[1] != default_index_col)){
+                // Missing column headers could arise from the first column serving as and index, if this is the case
+                // verify that the split_split header size is greater == 1 (e.g is it a vector) or that the next column
+                // value is not equal to the value of "default_index_col"
+                split_header[0] = default_index_col
+            }
+
         }
         if(headers){
             split_header = headers
         }
         while(line = it.readLine()){
-            split_line = line.tokenize(seperator)
+            split_line = line.split(seperator) // split will allow for missing values
             // Transpose, and collect converts the data to a map
-            converted_data[idx] = [split_header, split_line].transpose().collectEntries()
+            if(split_line.size() != split_header.size()){
+                error("The number of values in ${file_path} differs from number of columns headers ${split_header}")
+            }
+
+            def new_row = [split_header, split_line].transpose().collectEntries()
+            new_row.each{
+                if(!it.value){
+                    it.value = missing_value;
+                }
+            }
+            converted_data[idx] = new_row
             idx++
             lines_read = true
         }
         if(!lines_read){
-            converted_data[idx] = [split_header, Collections.nCopies(split_header.size, "NoData")].transpose().collectEntries()
+            converted_data[idx] = [split_header, Collections.nCopies(split_header.size, missing_value)].transpose().collectEntries()
         }
 
     }

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -837,7 +837,7 @@ def table_values(file_path, header_p, seperator, headers=null){
         }
     }
     def converted_data = rows_list.indexed().collectEntries { idx, row -> 
-        ["${idx}": row.collectEntries { k, v -> [(k): replace_missing(v)] }]
+        [(idx): row.collectEntries { k, v -> [(k): replace_missing(v)] }]
     }
     return converted_data
 }

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -813,8 +813,8 @@ def table_values(file_path, header_p, seperator, headers=null){
     } else if (!header_p) {
         if (file_lines.size() == 0) {
             // headers were not in the file, and file size is 0, so return missing data based
-            // on passed headers
-            rows_list = headers.collectEntries { [(it): null] }
+            // on passed headers (i.e., single row of empty values)
+            rows_list = [headers.collectEntries { [(it): null] }]
         } else {
             // verify that passed headers and rows have same number
             def row_line = file_lines[0].replaceAll('(\n|\r\n)$', '')
@@ -846,7 +846,8 @@ def table_values(file_path, header_p, seperator, headers=null){
 
         if (file_lines.size() == 1) {
             // There is no row lines, only headers, so return missing data
-            rows_list = headers_from_file.collectEntries { [(it): null] }
+            // (single row of empty values)
+            rows_list = [headers_from_file.collectEntries { [(it): null] }]
         } else {
             // If there exists a row line, then make sure rows + headers match
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1078,12 +1078,12 @@ dag {
 
 manifest {
     name            = 'phac-nml/mikrokondo'
-    author          = """matthew wells"""
+    author          = """Matthew Wells, James Robertson, Aaron Petkau, Christy-Lynn Peterson, Eric Marinier"""
     homePage        = 'https://github.com/phac-nml/mikrokondo'
-    description     = """Mikrokondo beta"""
+    description     = """Mikrokondo"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.2.0'
+    version         = '0.2.1'
     defaultBranch   = 'main'
     doi             = ''
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -76,14 +76,14 @@
             "properties": {
                 "dehosting_idx": {
                     "type": "string",
-                    "description": "Mash sketch used for contamination detection and speciation (Sketch comments must be a taxonomic string similar to what Kraken2 outputs)",
+                    "description": "Minimpa2 index for dehosting and kitome removal",
                     "pattern": "^\\S+$",
                     "exists": true,
                     "format": "file-path"
                 },
                 "mash_sketch": {
                     "type": "string",
-                    "description": "Minimpa2 index for dehosting and kitome removal",
+                    "description": "Mash sketch used for contamination detection and speciation (Sketch comments must be a taxonomic string similar to what Kraken2 outputs)",
                     "pattern": "^\\S+$",
                     "exists": true,
                     "format": "file-path"

--- a/tests/data/tables/all_values_missing.csv
+++ b/tests/data/tables/all_values_missing.csv
@@ -1,0 +1,1 @@
+header1,header2,header3

--- a/tests/data/tables/all_values_missing.csv
+++ b/tests/data/tables/all_values_missing.csv
@@ -1,1 +1,2 @@
 header1,header2,header3
+,,

--- a/tests/data/tables/header_missing_val.csv
+++ b/tests/data/tables/header_missing_val.csv
@@ -1,0 +1,2 @@
+,header2,header3
+stuff1,stuff2,stuff3

--- a/tests/data/tables/missing_all_headers.csv
+++ b/tests/data/tables/missing_all_headers.csv
@@ -1,0 +1,2 @@
+
+stuff1,stuff2,stuff3

--- a/tests/data/tables/missing_all_headers_single_line.csv
+++ b/tests/data/tables/missing_all_headers_single_line.csv
@@ -1,0 +1,1 @@
+stuff1,stuff2,stuff3

--- a/tests/data/tables/missing_last_value.tab
+++ b/tests/data/tables/missing_last_value.tab
@@ -1,0 +1,2 @@
+header1	header2	header3
+stuff1	stuff2

--- a/tests/data/tables/missing_multiple_value_separators.tab
+++ b/tests/data/tables/missing_multiple_value_separators.tab
@@ -1,0 +1,2 @@
+header1	header2	header3	header4
+stuff1	stuff2

--- a/tests/data/tables/missing_multiple_value_separators_extra_field.tab
+++ b/tests/data/tables/missing_multiple_value_separators_extra_field.tab
@@ -1,0 +1,2 @@
+header1	header2	header3	header4
+stuff1	stuff2		stuff4

--- a/tests/data/tables/mistmatch_headers_values.csv
+++ b/tests/data/tables/mistmatch_headers_values.csv
@@ -1,0 +1,2 @@
+header1,header2,header3
+stuff1,stuff2,stuff3,stuff4

--- a/tests/data/tables/mock_missing_value.csv
+++ b/tests/data/tables/mock_missing_value.csv
@@ -1,0 +1,2 @@
+header1,header2,header3
+,stuff2,stuff3

--- a/tests/data/tables/mock_missing_value.tab
+++ b/tests/data/tables/mock_missing_value.tab
@@ -1,0 +1,2 @@
+header1	header2	header3
+	stuff2	stuff3

--- a/tests/data/tables/mock_missing_value_2.tab
+++ b/tests/data/tables/mock_missing_value_2.tab
@@ -1,0 +1,2 @@
+header1	header2	header3
+		stuff3

--- a/tests/data/tables/no_header.csv
+++ b/tests/data/tables/no_header.csv
@@ -1,0 +1,1 @@
+stuff1,stuff2,stuff3

--- a/tests/data/tables/no_missing.csv
+++ b/tests/data/tables/no_missing.csv
@@ -1,0 +1,2 @@
+header1,header2,header3
+stuff1,stuff2,stuff3

--- a/tests/data/tables/no_missing.tab
+++ b/tests/data/tables/no_missing.tab
@@ -1,0 +1,2 @@
+header1	header2	header3
+stuff1	stuff2	stuff3

--- a/tests/data/tables/two_missing_headers.csv
+++ b/tests/data/tables/two_missing_headers.csv
@@ -1,0 +1,2 @@
+,,header3
+stuff1,stuff2,stuff3

--- a/tests/data/tables/vector.csv
+++ b/tests/data/tables/vector.csv
@@ -1,0 +1,4 @@
+header1
+stuff1
+stuff2
+stuff3

--- a/tests/data/tables/vector_no_hdr.csv
+++ b/tests/data/tables/vector_no_hdr.csv
@@ -1,0 +1,4 @@
+
+stuff1
+stuff2
+stuff3

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -300,4 +300,64 @@ nextflow_function {
             assert function.result == ['0':['header1':'NoData', 'header2':'NoData', 'header3':'NoData']]
         }
     }
+
+    test("Missing last two values"){
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/missing_last_value.tab")
+                input[1] = true
+                input[2] = '\t'
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.success
+            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'NoData']]
+        }
+    }
+
+    test("Missing multiple terminal value separators"){
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/missing_multiple_value_separators.tab")
+                input[1] = true
+                input[2] = '\t'
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.success
+            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'NoData', 'header4': 'NoData']]
+        }
+    }
+
+    test("Missing internal value separator"){
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/missing_multiple_value_separators.tab")
+                input[1] = true
+                input[2] = '\t'
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.success
+            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'NoData', 'header4': 'stuff4']]
+        }
+    }
 }

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -95,6 +95,7 @@ nextflow_function {
 
 
     test("Test csv, header supplied"){
+        tag "no_missing"
 
         when {
             function {
@@ -138,6 +139,7 @@ nextflow_function {
 
 
     test("Test csv, no header"){
+        tag "csv_no_header"
 
         when {
             function {

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -24,7 +24,7 @@ nextflow_function {
             }
         }
         then{
-            assert function.result == ['0':['header1':'', 'header2':'stuff2', 'header3':'stuff3']]
+            assert function.result == ['0':['header1':'NoData', 'header2':'stuff2', 'header3':'stuff3']]
             assert function.success
         }
     }
@@ -45,7 +45,7 @@ nextflow_function {
             }
         }
         then{
-            assert function.result == ['0':['header1':'', 'header2':'', 'header3':'stuff3']]
+            assert function.result == ['0':['header1':'NoData', 'header2':'NoData', 'header3':'stuff3']]
             assert function.success
         }
     }
@@ -88,7 +88,7 @@ nextflow_function {
             }
         }
         then{
-            assert function.result == ['0':['header1':'', 'header2':'stuff2', 'header3':'stuff3']]
+            assert function.result == ['0':['header1':'NoData', 'header2':'stuff2', 'header3':'stuff3']]
             assert function.success
         }
     }
@@ -297,7 +297,7 @@ nextflow_function {
         }
         then{
             assert function.success
-            assert function.result == ['0':['header1':'', 'header2':'', 'header3':'']]
+            assert function.result == ['0':['header1':'NoData', 'header2':'NoData', 'header3':'NoData']]
         }
     }
 }

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -207,6 +207,7 @@ nextflow_function {
     }
 
     test("Test empty file"){
+        tag "test_empty"
 
         when {
             function {
@@ -223,9 +224,31 @@ nextflow_function {
         }
         then{
             assert function.failed
+            assert function.stdout.any { it.contains("ERROR ~ Attempting to parse empty file") }
         }
     }
 
+    test("Test empty file pass header"){
+        tag "test_empty_pass_header"
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/empty.csv")
+                input[1] = false
+                input[2] = ','
+                input[3] = ['header1', 'header2']
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.success
+            assert function.result == ['0':['header1':'NoData', 'header2':'NoData']]
+        }
+    }
 
     test("Test more values than columns"){
 

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -288,7 +288,7 @@ nextflow_function {
         }
         then{
             assert function.failed
-            assert function.stdout.any { it.contains("ERROR ~ Mismatched number of headers [] and column values [stuff1, stuff2, stuff3] for file") }
+            assert function.stdout.any { it.contains("ERROR ~ Mismatched number of headers [__default_index__] and column values [stuff1, stuff2, stuff3] for file") }
         }
     }
 

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -349,6 +349,8 @@ nextflow_function {
     }
 
     test("Missing internal value separator"){
+        tag "missing_internal_separator"
+
         when {
             function {
                 """
@@ -364,7 +366,7 @@ nextflow_function {
         }
         then{
             assert function.success
-            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'NoData', 'header4': 'stuff4']]
+            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'NoData', 'header4': 'NoData']]
         }
     }
 }

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -1,0 +1,202 @@
+/*
+Tests for functions in the report module.
+*/
+
+
+nextflow_function {
+    name "Test report.nf functions"
+    script "modules/local/report.nf"
+    function "table_values"
+
+    test("Test tab missing column value, header supplied"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/mock_missing_value.tab")
+                input[1] = true
+                input[2] = '\t'
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.result == ['0':['header1':'NoData', 'header2':'stuff2', 'header3':'stuff3']]
+            assert function.success
+        }
+    }
+
+    test("Test tab missing 2 column values, header supplied"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/mock_missing_value_2.tab")
+                input[1] = true
+                input[2] = '\t'
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.result == ['0':['header1':'NoData', 'header2':'NoData', 'header3':'stuff3']]
+            assert function.success
+        }
+    }
+
+
+    test("Test tab, header supplied"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/no_missing.tab")
+                input[1] = true
+                input[2] = '\t'
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'stuff3']]
+            assert function.success
+        }
+    }
+
+    test("Test csv missing column value, header supplied"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/mock_missing_value.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.result == ['0':['header1':'NoData', 'header2':'stuff2', 'header3':'stuff3']]
+            assert function.success
+        }
+    }
+
+
+    test("Test csv, header supplied"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/no_missing.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'stuff3']]
+            assert function.success
+        }
+    }
+
+    test("Test csv, header missing one value"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/header_missing_val.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.success
+            assert function.result == ['0':['__default_index':'stuff1', 'header2':'stuff2', 'header3':'stuff3']]
+        }
+    }
+
+
+    test("Test csv, no header"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/no_header.csv")
+                input[1] = false
+                input[2] = ','
+                input[3] = ['header1', 'header2', 'header3']
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.success
+            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'stuff3']]
+        }
+    }
+
+
+    test("Test csv, two headers missing values"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/two_missing_headers.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.failed
+        }
+    }
+
+        test("Test csv, vector with header"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/vector.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.result == ['0':['header1':'stuff1'], '1': ['header1':'stuff2'], '2':['header1':'stuff3']]
+            assert function.success
+        }
+    }
+}

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -9,6 +9,7 @@ nextflow_function {
     function "table_values"
 
     test("Test tab missing column value, header supplied"){
+        tag "tab_missing_value"
 
         when {
             function {
@@ -117,6 +118,7 @@ nextflow_function {
     }
 
     test("Test csv, header missing one value"){
+        tag "header_missing_one_value"
 
         when {
             function {

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -247,6 +247,8 @@ nextflow_function {
     }
 
     test("Vector no column header"){
+        tag "vector_no_column_header"
+
         when {
             function {
                 """

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -164,6 +164,7 @@ nextflow_function {
 
 
     test("Test csv, two headers missing values"){
+        tag "two_headers_missing_values"
 
         when {
             function {

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -315,6 +315,8 @@ nextflow_function {
     }
 
     test("Missing last two values"){
+        tag "missing_last_two_values"
+
         when {
             function {
                 """
@@ -329,33 +331,13 @@ nextflow_function {
             }
         }
         then{
-            assert function.success
-            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'NoData']]
+            assert function.failed
+            assert function.stdout.any { it.contains("Mismatched number of headers [header1, header2, header3] and column values [stuff1, stuff2]") }
         }
     }
 
     test("Missing multiple terminal value separators"){
-        when {
-            function {
-                """
-                input[0] = file("$baseDir/tests/data/tables/missing_multiple_value_separators.tab")
-                input[1] = true
-                input[2] = '\t'
-                input[3] = null
-                """
-            }
-            params {
-                outdir = "results"
-            }
-        }
-        then{
-            assert function.success
-            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'NoData', 'header4': 'NoData']]
-        }
-    }
-
-    test("Missing internal value separator"){
-        tag "missing_internal_separator"
+        tag "missing_multiple_terminal_value_separators"
 
         when {
             function {
@@ -371,8 +353,8 @@ nextflow_function {
             }
         }
         then{
-            assert function.success
-            assert function.result == ['0':['header1':'stuff1', 'header2':'stuff2', 'header3':'NoData', 'header4': 'NoData']]
+            assert function.failed
+            assert function.stdout.any { it.contains("Mismatched number of headers [header1, header2, header3, header4] and column values [stuff1, stuff2]") }
         }
     }
 }

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -184,6 +184,7 @@ nextflow_function {
     }
 
     test("Test csv, vector with header"){
+        tag "csv_vector_header"
 
         when {
             function {
@@ -286,6 +287,8 @@ nextflow_function {
     }
 
     test("Missing all values"){
+        tag "missing_all_values"
+
         when {
             function {
                 """

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -298,7 +298,6 @@ nextflow_function {
         then{
             assert function.success
             assert function.result == ['0':['header1':'', 'header2':'', 'header3':'']]
-
         }
     }
 }

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -315,6 +315,30 @@ nextflow_function {
         }
     }
 
+    test("Missing all column headers, only single line"){
+        tag "missing_all_column_headers_single_line"
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/missing_all_headers_single_line.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.success
+            // When headers are supposed to exist in the file, but only a single line of values 
+            // will assume first line is headers
+            assert function.result == ['0':['stuff1':'NoData', 'stuff2':'NoData', 'stuff3':'NoData']]
+        }
+    }
+
     test("Missing all values"){
         tag "missing_all_values"
 

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -271,6 +271,8 @@ nextflow_function {
 
 
     test("Missing all column headers"){
+        tag "missing_all_column_headers"
+
         when {
             function {
                 """
@@ -286,6 +288,7 @@ nextflow_function {
         }
         then{
             assert function.failed
+            assert function.stdout.any { it.contains("ERROR ~ Mismatched number of headers [] and column values [stuff1, stuff2, stuff3] for file") }
         }
     }
 

--- a/tests/functions/report.nf.test
+++ b/tests/functions/report.nf.test
@@ -24,7 +24,7 @@ nextflow_function {
             }
         }
         then{
-            assert function.result == ['0':['header1':'NoData', 'header2':'stuff2', 'header3':'stuff3']]
+            assert function.result == ['0':['header1':'', 'header2':'stuff2', 'header3':'stuff3']]
             assert function.success
         }
     }
@@ -45,7 +45,7 @@ nextflow_function {
             }
         }
         then{
-            assert function.result == ['0':['header1':'NoData', 'header2':'NoData', 'header3':'stuff3']]
+            assert function.result == ['0':['header1':'', 'header2':'', 'header3':'stuff3']]
             assert function.success
         }
     }
@@ -88,7 +88,7 @@ nextflow_function {
             }
         }
         then{
-            assert function.result == ['0':['header1':'NoData', 'header2':'stuff2', 'header3':'stuff3']]
+            assert function.result == ['0':['header1':'', 'header2':'stuff2', 'header3':'stuff3']]
             assert function.success
         }
     }
@@ -132,7 +132,7 @@ nextflow_function {
         }
         then{
             assert function.success
-            assert function.result == ['0':['__default_index':'stuff1', 'header2':'stuff2', 'header3':'stuff3']]
+            assert function.result == ['0':['__default_index__':'stuff1', 'header2':'stuff2', 'header3':'stuff3']]
         }
     }
 
@@ -179,7 +179,7 @@ nextflow_function {
         }
     }
 
-        test("Test csv, vector with header"){
+    test("Test csv, vector with header"){
 
         when {
             function {
@@ -197,6 +197,108 @@ nextflow_function {
         then{
             assert function.result == ['0':['header1':'stuff1'], '1': ['header1':'stuff2'], '2':['header1':'stuff3']]
             assert function.success
+        }
+    }
+
+    test("Test empty file"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/empty.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.failed
+        }
+    }
+
+
+    test("Test more values than columns"){
+
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/mismatch_headers_values.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.failed
+        }
+    }
+
+    test("Vector no column header"){
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/vector_no_hdr.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.result == ['0':['__default_index__':'stuff1'], '1': ['__default_index__':'stuff2'], '2':['__default_index__':'stuff3']]
+            assert function.success
+        }
+    }
+
+
+    test("Missing all column headers"){
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/missing_all_headers.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.failed
+        }
+    }
+
+    test("Missing all values"){
+        when {
+            function {
+                """
+                input[0] = file("$baseDir/tests/data/tables/all_values_missing.csv")
+                input[1] = true
+                input[2] = ','
+                input[3] = null
+                """
+            }
+            params {
+                outdir = "results"
+            }
+        }
+        then{
+            assert function.success
+            assert function.result == ['0':['header1':'', 'header2':'', 'header3':'']]
+
         }
     }
 }


### PR DESCRIPTION

Previously missing values would cause a shift in the index of the map due to using the tokenize function instead of split. This as been reolved and tests have been added. This addresses issue: https://github.com/phac-nml/mikrokondo/issues/82

<!--
# mk-kondo/mikrokondo pull request

Many thanks for contributing to mk-kondo/mikrokondo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/mk-kondo/mikrokondo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] `CHANGELOG.md` is updated.

