### PR TITLE
Split/qc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### `Changed`
+
+- Reformatted QCSummary fields and added a QCMessage field containing the old summary message.
+
+### Fixed
+
+- Updated samtools/minimap2 container fixing CI issues and issues running the pipeline with Docker.
+
 ## [0.2.1] - 2024-06-03
 
 ### `Fixed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- Reformatted QCSummary fields and added a QCMessage field containing the old summary message.
+- Reformatted QCSummary fields and added a QCMessage field containing the old summary message. See [PR 85](https://github.com/phac-nml/mikrokondo/pull/85)
 
 ### Fixed
 
-- Updated samtools/minimap2 container fixing CI issues and issues running the pipeline with Docker.
+- Updated samtools/minimap2 container fixing CI issues and issues running the pipeline with Docker. See [PR 85](https://github.com/phac-nml/mikrokondo/pull/85)
 
 ## [0.2.1] - 2024-06-03
 

--- a/bin/report_summaries.py
+++ b/bin/report_summaries.py
@@ -6,7 +6,7 @@ TODO add static html table output
 Matthew Wells: 2023-09-22
 """
 from dataclasses import dataclass
-from typing import Dict, Union
+from typing import Dict, Optional
 from collections import defaultdict
 import os
 import argparse
@@ -22,14 +22,15 @@ class CleaningInfo:
     trim_field int: when split on a delimiter which section of the list to keep
     """
     field: str
-    keep: Union[str, None] = None
-    trim_field: Union[int, None] = None
+    keep: Optional[str] = None
+    trim_field: Optional[int] = None
 
 class JsonImport:
     """Intake json report to convert to CSV"""
 
     __key_order = {v.field: v for v in [CleaningInfo(field="QCStatus"),
                 CleaningInfo(field="QCSummary"),
+                CleaningInfo(field="QCMessage"),
                 CleaningInfo(field="QualityAnalysis", keep="message", trim_field=1),
                 CleaningInfo(field="meta")]}
     __keep_keys = frozenset(__key_order.keys())

--- a/bin/report_summaries.py
+++ b/bin/report_summaries.py
@@ -30,6 +30,7 @@ class JsonImport:
 
     __key_order = {v.field: v for v in [CleaningInfo(field="QCStatus"),
                 CleaningInfo(field="QCSummary"),
+                CleaningInfo(field="QCParameterSelection"),
                 CleaningInfo(field="QCMessage"),
                 CleaningInfo(field="QualityAnalysis", keep="message", trim_field=1),
                 CleaningInfo(field="meta")]}

--- a/conf/irida_next.config
+++ b/conf/irida_next.config
@@ -60,7 +60,7 @@ iridanext {
                     "QualityAnalysis.length.value"                   : "Length Value",
                     "QualityAnalysis.nr_contigs.qc_status"           : "nr contigs Status",
                     "QualityAnalysis.nr_contigs.value"               : "nr contigs Value",
-                    "QCSummary"                                      : "QC Summary",
+                    "QCMessage"                                      : "QC Message",
                     "meta.downsampled"                               : "Downsampled",
                     "SpeciesTopHit"                                  : "Species",
                     "ECTyperSubtyping.0.Database"                    : "ECTyper Database",
@@ -128,6 +128,7 @@ iridanext {
                 ]
                 keep = [
                     "QCStatus",
+                    "QCMessage",
                     "QualityAnalysis.checkm_contamination.qc_status",
                     "QualityAnalysis.checkm_contamination.value",
                     "QualityAnalysis.average_coverage.qc_status",
@@ -140,7 +141,6 @@ iridanext {
                     "QualityAnalysis.length.value",
                     "QualityAnalysis.nr_contigs.qc_status",
                     "QualityAnalysis.nr_contigs.value",
-                    "QCSummary",
                     "meta.downsampled",
                     "SpeciesTopHit",
                     "ECTyperSubtyping.0.Database",

--- a/conf/irida_next.config
+++ b/conf/irida_next.config
@@ -60,7 +60,7 @@ iridanext {
                     "QualityAnalysis.length.value"                   : "Length Value",
                     "QualityAnalysis.nr_contigs.qc_status"           : "nr contigs Status",
                     "QualityAnalysis.nr_contigs.value"               : "nr contigs Value",
-                    "QCMessage"                                      : "QC Message",
+                    "QCSummary"                                      : "QC Summary",
                     "meta.downsampled"                               : "Downsampled",
                     "SpeciesTopHit"                                  : "Species",
                     "ECTyperSubtyping.0.Database"                    : "ECTyper Database",
@@ -128,7 +128,7 @@ iridanext {
                 ]
                 keep = [
                     "QCStatus",
-                    "QCMessage",
+                    "QCSummary",
                     "QualityAnalysis.checkm_contamination.qc_status",
                     "QualityAnalysis.checkm_contamination.value",
                     "QualityAnalysis.average_coverage.qc_status",

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -367,7 +367,7 @@ def create_action_call(sample_data, species_tag){
                 sample_status = "PASSED"
             }
 
-            def organism_criteria = sample_data[val.key][species_tag][1].search
+            def organism_criteria = sample_data[val.key][species_tag]
             def tests_passed = "Passed Tests: ${checks - checks_failed - checks_ignored}/${checks}"
             qual_message.add(tests_passed)
 
@@ -670,12 +670,13 @@ def generate_qc_data(data, search_phrases, qc_species_tag){
     def top_hit_tag = params.top_hit_species.report_tag;
     def quality_analysis = "QualityAnalysis"
     def shortest_token = get_shortest_token(search_phrases)
+    def species_tag_location = 0
     for(k in data){
         if(!k.value.meta.metagenomic){
             def species = get_species(k.value[k.key][top_hit_tag], search_phrases, shortest_token)
             generate_coverage_data(data[k.key], params.coverage_calc_fields.bp_field, species) // update coverage first so its values can be used in generating qc messages
             data[k.key][quality_analysis] = get_qc_data_species(k.value[k.key], species)
-            data[k.key][qc_species_tag] = species
+            data[k.key][qc_species_tag] = species[species_tag_location]
         }else{
             data[k.key][quality_analysis] = ["Metagenomic": ["message": null, "status": false]]
             data[k.key][quality_analysis]["Metagenomic"].message = "The sample was determined to be metagenomic, summary metrics will not be generated" +

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -35,6 +35,7 @@ process REPORT{
     def data_stride = 3 // report values added in groups of three, e.g sample meta info, parameters, output file of interest
     def headers_list = 'headers' // ! TODO this string exists twice, need to fix that
     def arr_size = test_in.size()
+    def qc_species_tag = "QCParameterSelection"
     for(long i = 0; i < arr_size; i=i+data_stride){
         def meta_data = test_in[i]
         def report_tag = test_in[i+1]
@@ -76,8 +77,8 @@ process REPORT{
     def search_phrases = qc_params_species()
 
     // Add in quality information in place
-    generate_qc_data(sample_data, search_phrases)
-    create_action_call(sample_data)
+    generate_qc_data(sample_data, search_phrases, qc_species_tag)
+    create_action_call(sample_data, qc_species_tag)
 
 
     def json_converted_data = new JsonBuilder(sample_data).toPrettyString()
@@ -124,6 +125,7 @@ def generate_coverage_data(sample_data, bp_field, species){
             // Add fixed genome coverage for species if desired
             def species_data_pos = 1;
             if(base_counts_p
+                && species[species_data_pos] != null
                 && species[species_data_pos].containsKey("fixed_genome_size")
                 && species[species_data_pos].fixed_genome_size != null){
 
@@ -197,7 +199,7 @@ def populate_qual_message(qual_data){
 }
 
 // Action: Reisolate and resequence, resequence, all good.
-def create_action_call(sample_data){
+def create_action_call(sample_data, species_tag){
     /*Define criteria used to create base sketches
 
     TODO Need to test a falthrough sample (e.g. unspeciated to see what happens)
@@ -281,7 +283,6 @@ def create_action_call(sample_data){
             if(!meta_data.assembly){
                 // We should have reads as we assembled it
                 if(qual_data && qual_data.containsKey("raw_average_quality") && !qual_data.raw_average_quality.status){
-                    //qual_message.add(params.QCReportFields.raw_average_quality.low_msg)
                     resequence += 1
                     checks_failed += 1
                 }else if (qual_data && (!qual_data.containsKey("raw_average_quality") || !qual_data.raw_average_quality.status)){
@@ -343,7 +344,6 @@ def create_action_call(sample_data){
             checks += 1
 
 
-
             (reisolate, resequence) = n50_nrcontigs_decision(qual_data, nr_contigs_failed, n50_failed, qual_message, reisolate, resequence)
             //qual_message.add("Quality Conclusion")
 
@@ -366,15 +366,24 @@ def create_action_call(sample_data){
                 qual_message.add("[PASSED] All Checks passed")
                 sample_status = "PASSED"
             }
-            qual_message.add("Passed Tests: ${checks - checks_failed - checks_ignored}/${checks}")
 
+            def organism_criteria = sample_data[val.key][species_tag][1].search
+            def tests_passed = "Passed Tests: ${checks - checks_failed - checks_ignored}/${checks}"
+            qual_message.add(tests_passed)
 
-            qual_message.add("Species ID: ${val.value[val.key][params.top_hit_species.report_tag]}")
+            def species_id = "Species ID: ${val.value[val.key][params.top_hit_species.report_tag]}"
+            qual_message.add(species_id)
 
             // Qual summary not final message
             final_message = qual_message.join("\n")
             def terminal_message = populate_qual_message(qual_data).join("\n")
             log.info "\n$val.key\n${terminal_message}\n${sample_status}\n${final_message}"
+
+            // Reseq recommended should go to a seperate field
+            // Requested output should be: [PASS|FAILED] Species ID: [species] [Tests passed] [Organism criteria available]
+            qc_message = "${sample_status} ${species_id} ${tests_passed} Organism QC Criteria: ${organism_criteria}"
+
+            sample_data[val.key]["QCMessage"] = qc_message
             sample_data[val.key]["QCStatus"] = sample_status
             sample_data[val.key]["QCSummary"] = final_message
         }
@@ -606,7 +615,8 @@ def get_species(value, search_phrases, shortest_token){
         shortest_token: contains values to scrub from value to be searched for
     */
 
-    def qc_data = null;
+
+    def qc_data = [params.QCReport.fallthrough.search, params.QCReport.fallthrough];
     if(value == null){
         return qc_data
     }
@@ -627,7 +637,6 @@ def get_species(value, search_phrases, shortest_token){
 
 def get_qc_data_species(value_data, qc_data){
     def quality_messages = [:]
-
 
     params.QCReportFields.each{
         k, v ->
@@ -651,7 +660,7 @@ def get_qc_data_species(value_data, qc_data){
     return quality_messages;
 }
 
-def generate_qc_data(data, search_phrases){
+def generate_qc_data(data, search_phrases, qc_species_tag){
     /*
     data: sample data in a LazyMap
     search_phrases: normalized search phrases from the nextflow.config
@@ -664,9 +673,9 @@ def generate_qc_data(data, search_phrases){
     for(k in data){
         if(!k.value.meta.metagenomic){
             def species = get_species(k.value[k.key][top_hit_tag], search_phrases, shortest_token)
-            //generate_coverage_data(data[k.key], params.seqtk_size.report_tag, species) // update coverage first so its values can be used in generating qc messages
             generate_coverage_data(data[k.key], params.coverage_calc_fields.bp_field, species) // update coverage first so its values can be used in generating qc messages
             data[k.key][quality_analysis] = get_qc_data_species(k.value[k.key], species)
+            data[k.key][qc_species_tag] = species
         }else{
             data[k.key][quality_analysis] = ["Metagenomic": ["message": null, "status": false]]
             data[k.key][quality_analysis]["Metagenomic"].message = "The sample was determined to be metagenomic, summary metrics will not be generated" +

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -381,11 +381,11 @@ def create_action_call(sample_data, species_tag){
 
             // Reseq recommended should go to a seperate field
             // Requested output should be: [PASS|FAILED] Species ID: [species] [Tests passed] [Organism criteria available]
-            qc_message = "${sample_status} ${species_id} ${tests_passed} Organism QC Criteria: ${organism_criteria}"
+            qc_message = "${sample_status} ${species_id}; ${tests_passed}; Organism QC Criteria: ${organism_criteria}"
 
-            sample_data[val.key]["QCMessage"] = qc_message
+            sample_data[val.key]["QCSummary"] = qc_message
             sample_data[val.key]["QCStatus"] = sample_status
-            sample_data[val.key]["QCSummary"] = final_message
+            sample_data[val.key]["QCMessage"] = final_message
         }
 
 }

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -224,6 +224,9 @@ def create_action_call(sample_data){
 
 
     TODO creating a logic heavy function that needs to be refactored
+
+    For addressing the defect, the Passed and failed messeges have been broken up, all that remains is to have the
+    final summary, checks passed and checks failed
     */
 
     for(val in sample_data){
@@ -245,8 +248,7 @@ def create_action_call(sample_data){
                     final_message = "[FAILED] Sample was determined to be metagenomic, and this was not specied as" +
                     " a metagenomic run indicating contamination REISOLATION AND RESEQUENCING RECOMMENDED." +
                     "There is additionally a possibility that your sample could not be identified as it is novel and " +
-                    "not included in the mash sketch provided to the pipeline (however this would be very rare), "+
-                    "but if this is the case please disregard this message."
+                    "not included in the program used to taxonomically classify your pipeline (however this is an unlikely culprit)."
                 }
                 sample_data[val.key]["QCStatus"] = sample_status
                 sample_data[val.key]["QCSummary"] = final_message
@@ -290,7 +292,7 @@ def create_action_call(sample_data){
                 checks += 1
 
                 if(qual_data && qual_data.containsKey("average_coverage") && !qual_data.average_coverage.status){
-                    //qual_message.add(params.QCReportFields.average_coverage.low_msg)
+
                     if(meta_data.downsampled){
                         qual_message.add("The sample may have been downsampled too aggressively, if this is the cause please re-run sample with a different target depth.")
                     }
@@ -865,7 +867,7 @@ def table_values(file_path, header_p, seperator, headers=null){
         }
     }
 
-    return rows_list.indexed().collectEntries { idx, row -> 
+    return rows_list.indexed().collectEntries { idx, row ->
         [(idx): row.collectEntries { k, v -> [(k): replace_missing(v)] }]
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -430,8 +430,8 @@ params {
 
     r_contaminants {
         // container contains minimap2 and samtools
-        singularity = "https://depot.galaxyproject.org/singularity/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0"
-        docker = "quay.io/biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:8f2087d838e5270cd83b5a016667234429f16eea-0"
+        singularity = "https://depot.galaxyproject.org/singularity/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:3161f532a5ea6f1dec9be5667c9efc2afdac6104-0"
+        docker = "quay.io/biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:3161f532a5ea6f1dec9be5667c9efc2afdac6104-0"
         phix_fa = ""
         homo_sapiens_fa = ""
         pacbio_mg = ""

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -88,7 +88,7 @@ nextflow_pipeline {
             assert !iridanext_metadata.CSE.containsKey("Length Value")
             assert !iridanext_metadata.CSE.containsKey("nr contigs Status")
             assert !iridanext_metadata.CSE.containsKey("nr contigs Value")
-            assert iridanext_metadata.CSE."QC Summary" == "[FAILED] Sample is likely contaminated, REISOLATION AND RESEQUENCING RECOMMENDED\nPassed Tests: 0/6\nSpecies ID: null"
+            assert iridanext_metadata.CSE."QC Message" == "FAILED Species ID: null Passed Tests: 0/6 Organism QC Criteria: No organism specific QC data available."
 
             assert iridanext_metadata.CSE."Downsampled" == false
             assert !iridanext_metadata.CSE.containsKey("Species")
@@ -216,7 +216,7 @@ nextflow_pipeline {
             assert iridanext_metadata.short."Length Value" == 4949
             assert iridanext_metadata.short."nr contigs Status" == "WARNING"
             assert iridanext_metadata.short."nr contigs Value" == 1
-            assert iridanext_metadata.short."QC Summary" == "[FAILED] RESEQUENCING IS RECOMMENDED\nPassed Tests: 5/6\nSpecies ID: No Species Identified"
+            assert iridanext_metadata.short."QC Message" == "FAILED Species ID: No Species Identified Passed Tests: 5/6 Organism QC Criteria: No organism specific QC data available."
 
             assert iridanext_metadata.short."Downsampled" == false
             assert iridanext_metadata.short."Species" == "No Species Identified"

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -133,6 +133,7 @@ nextflow_pipeline {
         }
 
         then {
+
             assert workflow.success
             assert path("$launchDir/results").exists()
 

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -88,7 +88,7 @@ nextflow_pipeline {
             assert !iridanext_metadata.CSE.containsKey("Length Value")
             assert !iridanext_metadata.CSE.containsKey("nr contigs Status")
             assert !iridanext_metadata.CSE.containsKey("nr contigs Value")
-            assert iridanext_metadata.CSE."QC Message" == "FAILED Species ID: null Passed Tests: 0/6 Organism QC Criteria: No organism specific QC data available."
+            assert iridanext_metadata.CSE."QC Summary" == "FAILED Species ID: null; Passed Tests: 0/6; Organism QC Criteria: No organism specific QC data available."
 
             assert iridanext_metadata.CSE."Downsampled" == false
             assert !iridanext_metadata.CSE.containsKey("Species")
@@ -216,7 +216,7 @@ nextflow_pipeline {
             assert iridanext_metadata.short."Length Value" == 4949
             assert iridanext_metadata.short."nr contigs Status" == "WARNING"
             assert iridanext_metadata.short."nr contigs Value" == 1
-            assert iridanext_metadata.short."QC Message" == "FAILED Species ID: No Species Identified Passed Tests: 5/6 Organism QC Criteria: No organism specific QC data available."
+            assert iridanext_metadata.short."QC Summary" == "FAILED Species ID: No Species Identified; Passed Tests: 5/6; Organism QC Criteria: No organism specific QC data available."
 
             assert iridanext_metadata.short."Downsampled" == false
             assert iridanext_metadata.short."Species" == "No Species Identified"

--- a/tests/pipelines/main.from_assemblies.nf.test
+++ b/tests/pipelines/main.from_assemblies.nf.test
@@ -304,7 +304,7 @@ nextflow_pipeline {
             assert ecoli_metadata."Length Value" == 5299656
             assert ecoli_metadata."nr contigs Status" == "PASSED"
             assert ecoli_metadata."nr contigs Value" == 123
-            assert ecoli_metadata."QC Summary" == "[FAILED] Sample is likely contaminated, REISOLATION AND RESEQUENCING RECOMMENDED\nPassed Tests: 3/4\nSpecies ID: s__Escherichia coli"
+            assert ecoli_metadata."QC Message" == "FAILED Species ID: s__Escherichia coli Passed Tests: 3/4 Organism QC Criteria: Escherichia coli"
 
             // Read in filtered assembly fasta to verify number of contigs
             def assemblyLines = path("$launchDir/results/Assembly/FinalAssembly/ecoli_GCA_000947975/ecoli_GCA_000947975.final.filtered.assembly.fasta.gz").readLinesGzip()
@@ -393,7 +393,7 @@ nextflow_pipeline {
             assert salmonella_metadata."Length Value" == 4944000
             assert salmonella_metadata."nr contigs Status" == "PASSED"
             assert salmonella_metadata."nr contigs Value" == 3
-            assert salmonella_metadata."QC Summary" == "[FAILED] Sample is likely contaminated, REISOLATION AND RESEQUENCING RECOMMENDED\nPassed Tests: 3/4\nSpecies ID: s__Salmonella enterica"
+            assert salmonella_metadata."QC Message" == "FAILED Species ID: s__Salmonella enterica Passed Tests: 3/4 Organism QC Criteria: Salmonella"
 
             assert salmonella_metadata."Downsampled" == false
 
@@ -559,7 +559,7 @@ nextflow_pipeline {
             assert listeria_metadata."Length Value" == 2944528
             assert listeria_metadata."nr contigs Status" == "PASSED"
             assert listeria_metadata."nr contigs Value" == 1
-            assert listeria_metadata."QC Summary" == "[FAILED] Sample is likely contaminated, REISOLATION AND RESEQUENCING RECOMMENDED\nPassed Tests: 3/4\nSpecies ID: s__Listeria monocytogenes"
+            assert listeria_metadata."QC Message" == "FAILED Species ID: s__Listeria monocytogenes Passed Tests: 3/4 Organism QC Criteria: Listeria"
 
             assert listeria_metadata."Downsampled" == false
 

--- a/tests/pipelines/main.from_assemblies.nf.test
+++ b/tests/pipelines/main.from_assemblies.nf.test
@@ -121,7 +121,7 @@ nextflow_pipeline {
             assert ecoli_metadata."Length Value" == 5333525
             assert ecoli_metadata."nr contigs Status" == "PASSED"
             assert ecoli_metadata."nr contigs Value" == 187
-            assert ecoli_metadata."QC Message" == "FAILED Species ID: s__Escherichia coli Passed Tests: 3/4 Organism QC Criteria: Escherichia coli"
+            assert ecoli_metadata."QC Summary" == "FAILED Species ID: s__Escherichia coli; Passed Tests: 3/4; Organism QC Criteria: Escherichia coli"
 
             assert ecoli_metadata."Downsampled" == false
             assert ecoli_metadata."Species" == "s__Escherichia coli"
@@ -304,7 +304,7 @@ nextflow_pipeline {
             assert ecoli_metadata."Length Value" == 5299656
             assert ecoli_metadata."nr contigs Status" == "PASSED"
             assert ecoli_metadata."nr contigs Value" == 123
-            assert ecoli_metadata."QC Message" == "FAILED Species ID: s__Escherichia coli Passed Tests: 3/4 Organism QC Criteria: Escherichia coli"
+            assert ecoli_metadata."QC Summary" == "FAILED Species ID: s__Escherichia coli; Passed Tests: 3/4; Organism QC Criteria: Escherichia coli"
 
             // Read in filtered assembly fasta to verify number of contigs
             def assemblyLines = path("$launchDir/results/Assembly/FinalAssembly/ecoli_GCA_000947975/ecoli_GCA_000947975.final.filtered.assembly.fasta.gz").readLinesGzip()
@@ -393,7 +393,7 @@ nextflow_pipeline {
             assert salmonella_metadata."Length Value" == 4944000
             assert salmonella_metadata."nr contigs Status" == "PASSED"
             assert salmonella_metadata."nr contigs Value" == 3
-            assert salmonella_metadata."QC Message" == "FAILED Species ID: s__Salmonella enterica Passed Tests: 3/4 Organism QC Criteria: Salmonella"
+            assert salmonella_metadata."QC Summary" == "FAILED Species ID: s__Salmonella enterica; Passed Tests: 3/4; Organism QC Criteria: Salmonella"
 
             assert salmonella_metadata."Downsampled" == false
 
@@ -559,7 +559,7 @@ nextflow_pipeline {
             assert listeria_metadata."Length Value" == 2944528
             assert listeria_metadata."nr contigs Status" == "PASSED"
             assert listeria_metadata."nr contigs Value" == 1
-            assert listeria_metadata."QC Message" == "FAILED Species ID: s__Listeria monocytogenes Passed Tests: 3/4 Organism QC Criteria: Listeria"
+            assert listeria_metadata."QC Summary" == "FAILED Species ID: s__Listeria monocytogenes; Passed Tests: 3/4; Organism QC Criteria: Listeria"
 
             assert listeria_metadata."Downsampled" == false
 

--- a/tests/pipelines/main.from_assemblies.nf.test
+++ b/tests/pipelines/main.from_assemblies.nf.test
@@ -121,7 +121,7 @@ nextflow_pipeline {
             assert ecoli_metadata."Length Value" == 5333525
             assert ecoli_metadata."nr contigs Status" == "PASSED"
             assert ecoli_metadata."nr contigs Value" == 187
-            assert ecoli_metadata."QC Summary" == "[FAILED] Sample is likely contaminated, REISOLATION AND RESEQUENCING RECOMMENDED\nPassed Tests: 3/4\nSpecies ID: s__Escherichia coli"
+            assert ecoli_metadata."QC Message" == "FAILED Species ID: s__Escherichia coli Passed Tests: 3/4 Organism QC Criteria: Escherichia coli"
 
             assert ecoli_metadata."Downsampled" == false
             assert ecoli_metadata."Species" == "s__Escherichia coli"


### PR DESCRIPTION
This PR addresses a defect in which the final entire qc summary was not required and was not wanted. To address the issue a more striped down QC Message was generated and stored as part of the iridia-next.config leaving the original summary present but unwritten to the irida-next.config