### PR TITLE
added organism criteria field for final report if species id is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- Fixed null species ID in QCMessage when no organism qc data available.
+- Fixed null species ID in QCMessage when no organism qc data available. [PR 111](https://github.com/phac-nml/mikrokondo/pull/111)
 
 ## [0.4.0] - 2024-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## `Unreleased`
+
+### `Fixed`
+
+- Fixed null species ID in QCMessage when no organism qc data available.
+
 ## [0.4.0] - 2024-09-04
 
 ### `Changed`

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -373,7 +373,12 @@ def create_action_call(sample_data, species_tag){
             def tests_passed = "Passed Tests: ${checks - checks_failed - checks_ignored}/${checks}"
             qual_message.add(tests_passed)
 
-            def species_id = "Species ID: ${val.value[val.key][params.top_hit_species.report_tag]}"
+
+            def species_selected = val.value[val.key][params.top_hit_species.report_tag]
+            if(species_selected == null){
+                species_selected = organism_criteria
+            }
+            def species_id = "Species ID: ${species_selected}"
             qual_message.add(species_id)
 
             // Qual summary not final message

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -88,7 +88,7 @@ nextflow_pipeline {
             assert !iridanext_metadata.CSE.containsKey("Length Value")
             assert !iridanext_metadata.CSE.containsKey("nr contigs Status")
             assert !iridanext_metadata.CSE.containsKey("nr contigs Value")
-            assert iridanext_metadata.CSE."QC Summary" == "FAILED Species ID: null; Passed Tests: 0/6; Organism QC Criteria: No organism specific QC data available."
+            assert iridanext_metadata.CSE."QC Summary" == "FAILED Species ID: No organism specific QC data available.; Passed Tests: 0/6; Organism QC Criteria: No organism specific QC data available."
 
             assert iridanext_metadata.CSE."Downsampled" == false
             assert !iridanext_metadata.CSE.containsKey("predicted_identification_name")


### PR DESCRIPTION
Fixed issue: https://github.com/phac-nml/mikrokondo/issues/110