### PR TITLE
removed missing alleles from final aggregated report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## `Unreleased`
+
+### `Changed`
+
+- Removed missing alleles from final report fixing issue [112](https://github.com/phac-nml/mikrokondo/issues/112).
+
+
 ## [0.4.0] - 2024-09-04
 
 ### `Changed`

--- a/nextflow.config
+++ b/nextflow.config
@@ -257,6 +257,7 @@ params {
         data_sample_key = "sample_name"
         missing_allele_value = '-'
         reportable_alleles = []
+        report_exclude_fields = ["MissingAlleles"]
     }
 
     allele_scheme_selected {


### PR DESCRIPTION
The list of missing alleles was to extensive to include in the ffinal tabular summary so it is being removed.
