### PR TITLE
STRY0018072: Update ECTyper version 2.0.0 in mikrokondo to build 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Update`
 
-- Update SISTR docker/singularity build. [PR 170](https://github.com/phac-nml/mikrokondo/pull/170)
+- Update SISTR docker/singularity build (1->2). [PR 170](https://github.com/phac-nml/mikrokondo/pull/170)
+- Update ECTyper docker/singularity build (3->4). [PR 170](https://github.com/phac-nml/mikrokondo/pull/170)
 
 ## [0.6.1] - 2025-04-28
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -619,8 +619,8 @@ params {
     }
 
     ectyper {
-        singularity = 'https://depot.galaxyproject.org/singularity/ectyper:2.0.0--pyhdfd78af_1'
-        docker = 'biocontainers/ectyper:2.0.0--pyhdfd78af_3'
+        singularity = 'https://depot.galaxyproject.org/singularity/ectyper:2.0.0--pyhdfd78af_4 '
+        docker = 'biocontainers/ectyper:2.0.0--pyhdfd78af_4 '
         log_ext = ".log"
         tsv_ext = ".tsv"
         txt_ext = ".txt"


### PR DESCRIPTION
## Description

ECTyper to be updated in mikrokondo to be bioconda build 4 (latest version) so that I have the most recent code working in mikrokondo.

## Acceptance Criteria

- [x] Update ECTyper docker/singularity in mikrokondo to build 4: https://github.com/phac-nml/mikrokondo/blob/main/nextflow.config#L623
- [x] Make sure tests work