### PR TITLE
STRY0018071: Update SISTR build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the ECTyper speciation results to shigella outputs. [PR 166](https://github.com/phac-nml/mikrokondo/pull/166)
 
+### `Update`
+
+- Update SISTR docker/singularity build. [PR 170](https://github.com/phac-nml/mikrokondo/pull/170)
+
 ## [0.6.1] - 2025-04-28
 
 ### `Fixed`

--- a/nextflow.config
+++ b/nextflow.config
@@ -656,8 +656,8 @@ params {
     }
 
     sistr {
-        singularity = "https://depot.galaxyproject.org/singularity/sistr_cmd:1.1.3--pyhdc42f0e_0"
-        docker = 'biocontainers/sistr_cmd:1.1.3--pyhdc42f0e_1'
+        singularity = "https://depot.galaxyproject.org/singularity/sistr_cmd:1.1.3--pyhdc42f0e_2"
+        docker = 'biocontainers/sistr_cmd:1.1.3--pyhdc42f0e_2'
         tsv_ext = ".tab"
         allele_fasta_ext = ".allele.fasta"
         allele_json_ext = ".allele.json"


### PR DESCRIPTION
## STRY0018071: Update SISTR in mikrokondo to be bioconda build 2 for version 1.1.3

## Description
SISTR to be updated in mikrokondo to be bioconda build 2 (latest version) so that I have the most recent code working in mikrokondo.

## Criteria

- [x] Update mikrokondo docker/singularity to be the latest SISTR bioconda build for 1.1.3 (build 2) in https://github.com/phac-nml/mikrokondo/blob/main/nextflow.config#L660
- [x] Specifically this version: https://anaconda.org/bioconda/sistr_cmd/1.1.3/download/noarch/sistr_cmd-1.1.3-pyhdc42f0e_2.tar.bz2
- [x] Make sure tests all work