### PR TITLE
Add Nextflow version 25.10.4 to nf-test workflow GHA

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
-        profile: [conda, docker, singularity]
+        profile: [docker, singularity]
         isMain:
           - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
         # Exclude conda and singularity on dev

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
-        profile: [docker, singularity]
+        profile: [conda, docker, singularity]
         isMain:
           - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
         # Exclude conda and singularity on dev
@@ -76,9 +76,8 @@ jobs:
           - isMain: false
             profile: "singularity"
         NXF_VER:
-          - "24.10.3"
           - "25.10.4"
-
+          - "24.10.3"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}
@@ -88,26 +87,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Disk space cleanup # Clean up disk space to make more room for tests
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # Setting some to "false" since it takes time to remove files
-          # Changed back to "true" if extra space is needed
-          android: true
-          dotnet: false
-          haskell: false
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
       - name: Run nf-test
         id: run_nf_test
         uses: ./.github/actions/nf-test
-        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }} # Currently not testing latest-everything, but if we do, we don't want it to cause workflow failure
         env:
           NFT_WORKDIR: ${{ env.NFT_WORKDIR }}
           NXF_VERSION: ${{ matrix.NXF_VER }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -77,6 +77,7 @@ jobs:
             profile: "singularity"
         NXF_VER:
           - "24.10.3"
+          - "25.10.4"
 
     env:
       NXF_ANSI_LOG: false

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -87,6 +87,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Disk space cleanup # Clean up disk space to make more room for tests
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # Setting some to "false" since it takes time to remove files
+          # Changed back to "true" if extra space is needed
+          android: true
+          dotnet: false
+          haskell: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
       - name: Run nf-test
         id: run_nf_test
         uses: ./.github/actions/nf-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated StarAMR to version 0.12.1 [PR 217](https://github.com/phac-nml/mikrokondo/pull/217)
 
+- Set nextflow version 25.10.4 to replace 'latest-everything' to confirm compatibility with next IRIDA-Next nextflow version in `.github/workflows` for nf-test. [PR 219](https://github.com/phac-nml/mikrokondo/pull/219)
+
 ## 0.10.1 - 2026-2-16
 
 ### Added

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,6 @@
 */
 
 
-//
 // Global default params, used in configs
 params {
     // Input options

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,7 @@
 */
 
 
-
+//
 // Global default params, used in configs
 params {
     // Input options
@@ -1451,7 +1451,7 @@ manifest {
     description     = """Mikrokondo"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=24.10.3'
-    version         = '0.10.1-beta'
+    version         = '0.10.1'
     defaultBranch   = 'main'
     doi             = ''
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1451,7 +1451,7 @@ manifest {
     description     = """Mikrokondo"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=24.10.3'
-    version         = '0.10.1'
+    version         = '0.10.1-beta'
     defaultBranch   = 'main'
     doi             = ''
 }

--- a/nf-test.config
+++ b/nf-test.config
@@ -9,7 +9,7 @@ config {
     ignore 'modules/nf-core/**/tests/*', 'subworkflows/nf-core/**/tests/*'
 
     // list of filenames or patterns that should be trigger a full test run
-    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
+    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore', '.github/workflows/nf-test.yml'
 
     // load the necessary plugins
     plugins {


### PR DESCRIPTION
Add nextflow version 25.10.4 to the github actions for nf-test to confirm that pipeline is compatible with this version.