### PR TITLE
Update staramr 0.12.2

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
+        version: 25.10
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/nextflow.config
+++ b/nextflow.config
@@ -572,7 +572,7 @@ params {
 
     staramr {
         singularity = "https://depot.galaxyproject.org/singularity/staramr:0.12.1--pyhdfd78af_1"
-        docker = "biocontainers/staramr:0.12.1--pyhdfd78af_1"
+        docker = "biocontainers/staramr:0.12.2--pyhdfd78af_0"
         point_finder_db_default = null
         db = null
         tsv_ext = ".tsv"

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -76,7 +76,7 @@
                     "spades": "3.15.5"
                 },
                 "STARAMR": {
-                    "staramr": "0.12.1"
+                    "staramr": "0.12.2"
                 },
                 "Workflow": {
                     "phac-nml/mikrokondo": "0.10.1"
@@ -291,8 +291,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.8"
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2026-03-11T09:39:12.929143381"
+        "timestamp": "2026-05-06T08:48:21.221951722"
     }
 }


### PR DESCRIPTION
Updated the version of starAMR to [0.12.2](https://github.com/phac-nml/staramr/releases/tag/0.12.2) and updated the tests to:
- Have start/stop positions be integers in the detailed summary files (fix in the @[ release](https://github.com/phac-nml/staramr/releases/tag/0.12.2))
- Have floats for %Identity and %Overlap with an undefined decimal place [An issue is flagged and will be set to fixed decimal place]