### PR TITLE
STRY0021253 - Fix mikrokondo so that it works with Nextflow 25.10 in Azure

### DIFF
--- a/modules/local/parse_mash.nf
+++ b/modules/local/parse_mash.nf
@@ -20,7 +20,7 @@ process PARSE_MASH{
     script:
     //def taxa_path = (equivalent_taxa != null) && equivalent_taxa.exists() ? "-e $equivalent_taxa" : ""
     """
-    mash_parse.py -r $run_mode -i $mash_screen -e $equivalent_taxa
+    mash_parse.py -r $run_mode -i $mash_screen
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/parse_mash.nf
+++ b/modules/local/parse_mash.nf
@@ -18,9 +18,9 @@ process PARSE_MASH{
     path "versions.yml", emit: versions
 
     script:
-    def taxa_path = (equivalent_taxa != null) && equivalent_taxa.exists() ? "-e $equivalent_taxa" : ""
+    //def taxa_path = (equivalent_taxa != null) && equivalent_taxa.exists() ? "-e $equivalent_taxa" : ""
     """
-    mash_parse.py -r $run_mode -i $mash_screen $taxa_path
+    mash_parse.py -r $run_mode -i $mash_screen -e $equivalent_taxa
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/parse_mash.nf
+++ b/modules/local/parse_mash.nf
@@ -18,7 +18,7 @@ process PARSE_MASH{
     path "versions.yml", emit: versions
 
     script:
-    def taxa_path = equivalent_taxa && equivalent_taxa.exists() ? "-e $equivalent_taxa" : ""
+    def taxa_path = (equivalent_taxa != null) && equivalent_taxa.exists() ? "-e $equivalent_taxa" : ""
     """
     mash_parse.py -r $run_mode -i $mash_screen $taxa_path
 

--- a/subworkflows/local/clean_reads.nf
+++ b/subworkflows/local/clean_reads.nf
@@ -202,8 +202,8 @@ workflow QC_READS {
             }
         }
         else{
-            def taxa_file = file([projectDir, "conf", "equivalent_taxa.json"].join(File.separator))
-            parsed_mash = PARSE_MASH(mash_screen_out.mash_data, taxa_file, Channel.value("classify")) // Classify is passed to tell the script to determine if the sample is metagenomic or not
+            def taxa_file_ch = channel.value(file([projectDir, "conf", "equivalent_taxa.json"].join(File.separator)))
+            parsed_mash = PARSE_MASH(mash_screen_out.mash_data, taxa_file_ch, Channel.value("classify")) // Classify is passed to tell the script to determine if the sample is metagenomic or not
 
             // Update file metadata
             ch_cleaned_temp = ch_prepped_reads.join(parsed_mash.mash_out, remainder: true).map {


### PR DESCRIPTION
**Description**

As a pipeline developer, I would like mikrokondo to be fixed so that it works in Nextflow 25.10 when run in Azure batch, so that we can update Nextflow to 25.10 in GSP.

**Acceptance Criteria**

- [x] Mikrokondo runs with default parameters using Nextflow 25.10 (Nextflow currently updated in DEV environment).
- [ ] Test suite works with Nextflow 25.10.7
- [ ] (**NOT ADDED**) If issue is identified, and if it's possible, a test case should be added to our test suite to make sure we've resolved the issue.
  - [x] If it's complicated to add a test case for this specific issue, we can instead only rely on testing running mikrokondo in the DEV and TEST environments and make sure it's working.
- [ ] A new release of mikrokondo is made and updated in DEV (and works in DEV).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/mk-kondo/mikrokondo/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
